### PR TITLE
fix: allow selecting text on stake card

### DIFF
--- a/src/components/StakeCard/styles.ts
+++ b/src/components/StakeCard/styles.ts
@@ -3,7 +3,9 @@ import theme from '../../styles/theme'
 
 import * as ButtonStyles from '../Button/styles'
 
-export const StakeCard = styled.div``
+export const StakeCard = styled.div`
+  z-index: 1;
+`
 
 interface IBorderGradientProps {
   stakeWithVotingPower: boolean;
@@ -17,7 +19,7 @@ export const BorderGradient = styled.div<IBorderGradientProps>`
   position: relative;
   width: 295px;
   max-height: 100%;
-  z-index: 1;
+  z-index: -1;
 
   @media (max-width: 420px) {
     max-width: 100%;


### PR DESCRIPTION
The user can't select text on the current stake card, this changes some ordering to allow text selection in case the user wishes to copy something.