### PR TITLE
fix: allow farm page when disconnected

### DIFF
--- a/src/templates/Farm/index.tsx
+++ b/src/templates/Farm/index.tsx
@@ -49,7 +49,7 @@ const StakeFarm = () => {
             <Loading />
           </h1>
         ) : (
-          userWalletAddress.length === 0
+          userWalletAddress.length === 0 && chainId !== chains.fuji.chainId
             ? (
               <Web3Disabled
                 textButton="Connect Wallet"


### PR DESCRIPTION
Still needs to be on the correct chain, if not then it first asks to connect because Metamask mobile needs connection before changing chain.