### PR TITLE
fix: wrong APR for LP token

### DIFF
--- a/src/components/StakeCard/YourStake/index.tsx
+++ b/src/components/StakeCard/YourStake/index.tsx
@@ -48,12 +48,22 @@ const YourStake = ({
           new BigNumber(86400)
         )
 
+        const stakingTokenPrice =
+          pid === 5 ? priceLPToken.priceLP : priceLPToken.kacy
+
         const apr =
-          poolInfoResponse.depositedAmount.toString() !== '0'
-            ? kacyRewards
-                .mul(new BigNumber(365))
-                .mul(new BigNumber(100))
-                .div(new BigNumber(poolInfoResponse.depositedAmount))
+          poolInfoResponse.depositedAmount.toString() !== '0' &&
+          priceLPToken.kacy.gt('-1') &&
+          stakingTokenPrice.gt('-1')
+            ? new BigNumber(
+                Big(kacyRewards.toString())
+                  .mul('365')
+                  .mul('100')
+                  .mul(priceLPToken.kacy)
+                  .div(stakingTokenPrice)
+                  .div(Big(poolInfoResponse.depositedAmount.toString()))
+                  .toFixed(0)
+              )
             : new BigNumber(0)
 
         const startDate = getDate(
@@ -91,12 +101,22 @@ const YourStake = ({
       )
       const unstakeResponse = await unstaking(pid, userWalletAddress)
 
+      const stakingTokenPrice =
+        pid === 5 ? priceLPToken.priceLP : priceLPToken.kacy
+
       const apr =
-        poolInfoResponse.depositedAmount.toString() !== '0'
-          ? kacyRewards
-              .mul(new BigNumber(365))
-              .mul(new BigNumber(100))
-              .div(new BigNumber(poolInfoResponse.depositedAmount))
+        poolInfoResponse.depositedAmount.toString() !== '0' &&
+        priceLPToken.kacy.gt('-1') &&
+        stakingTokenPrice.gt('-1')
+          ? new BigNumber(
+              Big(kacyRewards.toString())
+                .mul('365')
+                .mul('100')
+                .mul(priceLPToken.kacy)
+                .div(stakingTokenPrice)
+                .div(Big(poolInfoResponse.depositedAmount.toString()))
+                .toFixed(0)
+            )
           : new BigNumber(0)
 
       const startDate = getDate(


### PR DESCRIPTION
We forgot to use USD values for calculating APR for staking pools using a currency other than Kacy.